### PR TITLE
Added scale hover effect on GitHub Button | Issue #88

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -65,7 +65,7 @@ const Dashboard = () => {
             <div className='space-y-4 sm:flex sm:space-y-0 sm:space-x-4'>
               <a
                 href='https://github.com/aashay28/GitBoard'
-                className='inline-flex items-center justify-center w-full px-5 py-3 text-sm font-medium text-center text-gray-900 border border-gray-500 rounded-lg sm:w-auto hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-gray-800 dark:border-gray-800 dark:hover:bg-gray dark:focus:ring-gray-800'
+                className='inline-flex items-center justify-center w-full px-5 py-3 text-sm font-medium text-center text-gray-900 border border-gray-500 rounded-lg sm:w-auto hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-gray-800 dark:border-gray-800 dark:hover:bg-gray dark:focus:ring-gray-800 transition duration:500 hover:scale-110 ease-in-out'
               >
                 <svg
                   className='w-4 h-4 mr-2 text-gray-500 dark:text-gray-400'


### PR DESCRIPTION
As per Issue #88 , I've added a transition hover effect on the "View on GitHub" button in the dashboard as shown below.

## Before

https://github.com/aashay28/GitBoard/assets/110970889/c124ed07-dcc7-4174-bf9d-2efa16339a38

## After

https://github.com/aashay28/GitBoard/assets/110970889/20de6d88-9491-4967-b838-82bd27e778e6
