### PR TITLE
Navigated to connections page after enter pressed | Issue #86

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -13,6 +13,11 @@ const Dashboard = () => {
   const handleInputChange = (event) => {
     setUsername(event.target.value);
   };
+  const handleKeyDown = async (event) => {
+    if(event.key === 'Enter'){
+      handleEnterClick()
+    }
+  }
   const handleEnterClick = async () => {
     setUserDetail(await fetchApi(`users/${username}`));
     navigate('/connections');
@@ -31,6 +36,7 @@ const Dashboard = () => {
               placeholder='Enter your github username'
               className='bg-transparent w-32 md:w-64 focus:outline-none relative'
               onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
               required
             />
           </div>


### PR DESCRIPTION
When user enters the github name in Dashboard section and press enter then it was not navigating to the connections page. This portion is fixed in this PR.